### PR TITLE
Refs hootsuite/pre-commit-php#2 - escaping comma

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ If you have multiple standards or a comma in your `args` property, escape the co
   hooks:
   - id: php-cs
     files: \.(php)$
-    args: [--standard=PSR1/,path/to/ruleset.xml -p]
+    args: ["--standard=PSR1/,path/to/ruleset.xml", "-p"]
 ```
 
 To install PHP Codesniffer, follow the [recommended steps here](https://github.com/squizlabs/PHP_CodeSniffer#installation).

--- a/pre_commit_hooks/php-cs.sh
+++ b/pre_commit_hooks/php-cs.sh
@@ -43,10 +43,7 @@ fi
 
 phpcs_files_to_check="${@:2}"
 phpcs_args=$1
-# Without this escape field, the parameters would break if there was a comma in it
-escape_comma="/,"
-phpcs_args_parsed="${phpcs_args:escape_comma:,}"
-phpcs_command="$phpcs_command $phpcs_args_parsed $phpcs_files_to_check"
+phpcs_command="$phpcs_command $phpcs_args $phpcs_files_to_check"
 
 echo "Running command $phpcs_command"
 command_result=`eval $phpcs_command`

--- a/pre_commit_hooks/php-cs.sh
+++ b/pre_commit_hooks/php-cs.sh
@@ -14,9 +14,9 @@
 # - None
 
 # Echo Colors
-msg_color_magenta='\e[1;35m'
-msg_color_yellow='\e[0;33m'
-msg_color_none='\e[0m' # No Color
+msg_color_magenta='\033[1;35m'
+msg_color_yellow='\033[0;33m'
+msg_color_none='\033[0m' # No Color
 
 # Loop through the list of paths to run php codesniffer against
 echo -en "${msg_color_yellow}Begin PHP Codesniffer ...${msg_color_none} \n"


### PR DESCRIPTION
Refs hootsuite/pre-commit-php#2 - I believe escaping the comma is not really an issue and is a documentation problem. In YAML, the comma is being interpreted as an array separator. To prevent this, the string containing the comma should be enclosed in quotes.

This PR also includes a small fix for colours on OS X.