### PR TITLE
Update shebang's to work with FreeBSD

### DIFF
--- a/pre_commit_hooks/php-cbf.sh
+++ b/pre_commit_hooks/php-cbf.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Bash PHP Code Beautifier and Fixer Hook
 # This script fails if the PHP Code Beautifier and Fixer output has the word "ERROR" in it.

--- a/pre_commit_hooks/php-cs-fixer.sh
+++ b/pre_commit_hooks/php-cs-fixer.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 ################################################################################
 #
 # Bash PHP Coding Standards Fixer

--- a/pre_commit_hooks/php-cs.sh
+++ b/pre_commit_hooks/php-cs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Bash PHP Codesniffer Hook
 # This script fails if the PHP Codesniffer output has the word "ERROR" in it.

--- a/pre_commit_hooks/php-lint.sh
+++ b/pre_commit_hooks/php-lint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Bash PHP Linter for Pre-commits
 #

--- a/pre_commit_hooks/php-unit.sh
+++ b/pre_commit_hooks/php-unit.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Bash PHP Unit Task Runner
 #


### PR DESCRIPTION
FreeBSD doesn't have bash installed by default, and when you do install it, it goes to /usr/local/bin/bash.  This change should allow the scripts to run regardless of where bash is installed.

Even better would be for these to be converted to be /bin/sh compatible.