### PR TITLE
adds the option to provide a custom phpunit command via args

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ Just add to your `.pre-commit-config.yaml` file with the following
 ## php-lint
 
 ```yaml
-<<<<<<< HEAD
 - repo: git@github.com:hootsuite/pre-commit-php.git
   sha: 1.1.0
   hooks:
@@ -47,7 +46,6 @@ A systems hook that just runs `php -l` against stage files that have the `.php` 
 
 ## php-unit
 
-
 ```yaml
 - repo: git@github.com:hootsuite/pre-commit-php.git
   sha: 1.1.0
@@ -58,6 +56,8 @@ A systems hook that just runs `php -l` against stage files that have the `.php` 
 A bash script that will run the appropriate phpunit executable. It will assume
   - Find the executable to run at either `vendor/bin/phpunit`, `phpunit` or `php phpunit.phar` (in that exact order).
   - There is already a `phpunit.xml` in the root of the repo
+
+*Optional:* You can provide a custom command as an argument, this will overwrite the default behavior and enables you to further customize your php-unit setup. e.g.: `args: ["composer run php-unit"]`
 
 Note in its current state, it will run the whole PHPUnit test as along as `.php` file was committed.
 

--- a/pre_commit_hooks/php-unit.sh
+++ b/pre_commit_hooks/php-unit.sh
@@ -2,6 +2,9 @@
 
 # Bash PHP Unit Task Runner
 #
+# php-unit command is run via composer run command
+# so you can for example execute php-unit via a docker container
+#
 # Exit 0 if no errors found
 # Exit 1 if errors were found
 #
@@ -9,43 +12,50 @@
 # - php
 #
 # Arguments
-# - None
+# - : Your custom phpunit command
 
 # Echo Colors
 msg_color_magenta='\e[1;35m'
 msg_color_yellow='\e[0;33m'
 msg_color_none='\e[0m' # No Color
 
-# Loop through the list of paths to run php lint against
+# Check if a custom phpunit command was provided as argument
+phpunit_custom_command=$1;
+
+# Loop through the list of paths to run phpunit against
 echo -en "${msg_color_yellow}Begin PHP Unit Task Runner ...${msg_color_none} \n"
 
-phpunit_local_exec="phpunit.phar"
-phpunit_command="php $phpunit_local_exec"
+if [ "$phpunit_custom_command" = "" ]; then
+  phpunit_local_exec="phpunit.phar"
+  phpunit_command="php $phpunit_local_exec"
 
-# Check vendor/bin/phpunit
-phpunit_vendor_command="vendor/bin/phpunit"
-phpunit_global_command="phpunit"
-if [ -f "$phpunit_vendor_command" ]; then
-	phpunit_command=$phpunit_vendor_command
-else
+  # Check vendor/bin/phpunit
+  phpunit_vendor_command="vendor/bin/phpunit"
+  phpunit_global_command="phpunit"
+  if [ -f "$phpunit_vendor_command" ]; then
+    phpunit_command=$phpunit_vendor_command
+  else
     if hash phpunit 2>/dev/null; then
-        phpunit_command=$phpunit_global_command
+      phpunit_command=$phpunit_global_command
     else
-        if [ -f "$phpunit_local_exec" ]; then
-            phpunit_command=$phpunit_command
-        else
-            echo "No valid PHP Unit executable found! Please have one available as either $phpunit_vendor_command, $phpunit_global_command or $phpunit_local_exec"
-            exit 1
-        fi
+      if [ -f "$phpunit_local_exec" ]; then
+        phpunit_command=$phpunit_command
+      else
+        echo "No valid PHP Unit executable found! Please have one available as either $phpunit_vendor_command, $phpunit_global_command or $phpunit_local_exec"
+        exit 1
+      fi
     fi
+  fi
+else
+  phpunit_command=$phpunit_custom_command
 fi
 
 echo "Running command $phpunit_command"
 command_result=`eval $phpunit_command`
 if [[ $command_result =~ FAILURES ]]
 then
-    echo "Failures detected in unit tests..."
-    echo "$command_result"
-    exit 1
+  echo "Failures detected in unit tests..."
+  echo "$command_result"
+  exit 1
 fi
 exit 0


### PR DESCRIPTION
This feature extends the php-unit hook to allow a custom command for the php-unit tests. This is useful if you want to use https://github.com/fiunchinho/phpunit-randomizer or if you have a more complicated php configuration running as a docker-container.

To illustrate, here's short excerpt from a composer.json
```javascript
"scripts": {
  "docker-run": "docker run --rm -v $PWD:/var/www dockerimage:latest",
  "php-unit": "@composer run docker-run -- ./var/www/vendor/bin/phpunit-randomizer -c /var/www/phpunit.xml --order rand",
  "test": "@composer run php-unit"
}
```

By running composer run test the scripts will start a docker-container and run the unit tests on it instead on your local php installation.

To configure the hook you would use:
```yaml
id: php-unit
args: ["composer run php-unit"]
```