### PR TITLE
Add support for PHPUnit options to php-unit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,42 @@
+- id: php-lint-all
+  name: PHP Syntax Check (Comprehensive)
+  description: Check PHP Syntax on ALL PHP staged files with user friendly messages and colors
+  entry: pre_commit_hooks/php-lint.sh
+  language: script
+  files: \.php$
+  args: [-s all]
+
+- id: php-lint
+  name: PHP Syntax Check (Quick)
+  description: Runs php -l on all staged files. Exits when it hits the first errored file
+  entry: php -l
+  language: system
+  files: \.php$
+
+- id: php-unit
+  name: PHP Unit
+  description: Run the full php unit test. Checks which PHPUnit executable is available first and then runs it. Preference order is vendor/bin, phpunit and phpunit.phar.
+  entry: pre_commit_hooks/php-unit.sh
+  language: script
+  files: \.php$
+
+- id: php-cs
+  name: PHP Codesniffer
+  description: Run php codesniffer against all staged files.
+  entry: pre_commit_hooks/php-cs.sh
+  language: script
+  files: \.php$
+
+- id: php-cbf
+  name: PHP Codesniffer (Code Beutifier and Formatter)
+  description: Run php codesniffer against all staged files.
+  entry: pre_commit_hooks/php-cbf.sh
+  language: script
+  files: \.php$
+
+- id: php-cs-fixer
+  name: PHP Coding Standards Fixer
+  description: Run php coding standards fixer against all staged files.
+  entry: pre_commit_hooks/php-cs-fixer.sh
+  language: script
+  files: \.php$

--- a/pre_commit_hooks/helpers/locate.sh
+++ b/pre_commit_hooks/helpers/locate.sh
@@ -15,7 +15,7 @@ if [ -f "$vendor_command" ]; then
 elif hash $global_command 2>/dev/null; then
     exec_command=$global_command
 elif [ -f "$local_command" ]; then
-    phpcsfixer_command=$prefixed_local_command
+    exec_command=$prefixed_local_command
 else
     echo -e "${bldred}No valid ${title} found!${txtrst}"
     echo "Please have one available as one of the following:"

--- a/pre_commit_hooks/php-unit.sh
+++ b/pre_commit_hooks/php-unit.sh
@@ -19,6 +19,17 @@ msg_color_none='\e[0m' # No Color
 # Loop through the list of paths to run php lint against
 echo -en "${msg_color_yellow}Begin PHP Unit Task Runner ...${msg_color_none} \n"
 
+args=""
+files=()
+for arg in ${*}
+do
+    if [ -f $arg ]; then
+        files+=("$arg")
+    else
+        args+=" $arg"
+    fi
+done;
+
 phpunit_local_exec="phpunit.phar"
 phpunit_command="php $phpunit_local_exec"
 
@@ -40,8 +51,8 @@ else
     fi
 fi
 
-echo "Running command $phpunit_command"
-command_result=`eval $phpunit_command`
+echo "Running command $phpunit_command ${args}"
+command_result=`eval $phpunit_command ${args}`
 if [[ $command_result =~ FAILURES ]]
 then
     echo "Failures detected in unit tests..."


### PR DESCRIPTION
Adds options to phpunit hook. In my case i have a subfolder with test. I need to add the path to the phpunit.xml or phpuni.xml.dist file (or the folder containing the file).

Example:

```yaml
hooks:
   - id: php-unit
      args:
         - "-c"
         - "tests/unit"
         - "debug"
```