### PR TITLE
Use env in shebangs

### DIFF
--- a/pre_commit_hooks/php-cbf.sh
+++ b/pre_commit_hooks/php-cbf.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Bash PHP Code Beautifier and Fixer Hook
 # This script fails if the PHP Code Beautifier and Fixer output has the word "ERROR" in it.

--- a/pre_commit_hooks/php-cs-fixer.sh
+++ b/pre_commit_hooks/php-cs-fixer.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 ################################################################################
 #
 # Bash PHP Coding Standards Fixer

--- a/pre_commit_hooks/php-cs.sh
+++ b/pre_commit_hooks/php-cs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Bash PHP Codesniffer Hook
 # This script fails if the PHP Codesniffer output has the word "ERROR" in it.

--- a/pre_commit_hooks/php-lint.sh
+++ b/pre_commit_hooks/php-lint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Bash PHP Linter for Pre-commits
 #

--- a/pre_commit_hooks/php-unit.sh
+++ b/pre_commit_hooks/php-unit.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Bash PHP Unit Task Runner
 #


### PR DESCRIPTION
Using /usr/bin/env $interpreter in shebangs is the "proper" way to do it instead of using the absolute path to interpreters.

It's very rare for /bin/bash to not exist, but it does occur. I don't have /bin/bash (as you might have guessed :P), the only thing in /bin that I have is /bin/sh :)

P.S. Sorry for the duplicate; I decided to resend the pull request even though you don't seem to be responding to anything.